### PR TITLE
Fix include problem

### DIFF
--- a/vpad_functions.h
+++ b/vpad_functions.h
@@ -28,10 +28,10 @@
 extern "C" {
 #endif
 
+#include <gctypes.h>
+
 extern u32 vpad_handle;
 extern u32 vpadbase_handle;
-
-#include <gctypes.h>
 
 #define VPAD_BUTTON_A        0x8000
 #define VPAD_BUTTON_B        0x4000


### PR DESCRIPTION
_gctypes.h_ needs to be included before using **u32** type.

If you don't do it, you will get these two compiler errors:
```
vpad_functions.h:31:8: error: 'u32' does not name a type
 extern u32 vpad_handle;
        ^~~
vpad_functions.h:32:8: error: 'u32' does not name a type
 extern u32 vpadbase_handle;
        ^~~
```