### PR TITLE
Space savings, memory functions, .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Build artifacts
+*.o

--- a/os_functions.c
+++ b/os_functions.c
@@ -101,6 +101,7 @@ EXPORT_DECL(void *, MEMDestroyExpHeap, s32 heap);
 EXPORT_DECL(void, MEMFreeToExpHeap, s32 heap, void* ptr);
 EXPORT_DECL(void *, OSAllocFromSystem, int size, int alignment);
 EXPORT_DECL(void, OSFreeToSystem, void *addr);
+EXPORT_DECL(int, OSIsAddressValid, void *ptr);
 
 //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 //! MCP functions
@@ -272,6 +273,7 @@ void InitOSFunctionPointers(void)
     OS_FIND_EXPORT(coreinit_handle, MEMFreeToExpHeap);
     OS_FIND_EXPORT(coreinit_handle, OSAllocFromSystem);
     OS_FIND_EXPORT(coreinit_handle, OSFreeToSystem);
+    OS_FIND_EXPORT(coreinit_handle, OSIsAddressValid);
 
     //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     //! Other function addresses

--- a/os_functions.c
+++ b/os_functions.c
@@ -149,9 +149,40 @@ EXPORT_DECL(s32, IOS_Ioctl,s32 fd, u32 request, void *input_buffer,u32 input_buf
 EXPORT_DECL(s32, IOS_Open,char *path, u32 mode);
 EXPORT_DECL(s32, IOS_Close,s32 fd);
 
+void _os_find_export(u32 handle, const char *funcName, void *funcPointer)
+{
+    OSDynLoad_FindExport(handle, 0, funcName, funcPointer);
+
+    if(!*(u32 *)funcPointer) {
+        /*
+         * This is effectively OSFatal("Function %s is NULL", funcName),
+         * but we can't rely on any library functions like snprintf or
+         * strcpy at this point.
+         *
+         * Buffer bounds are not checked. Beware!
+         */
+        char buf[256], *bufp = buf;
+        const char a[] = "Function ", b[] = " is NULL", *p;
+        int i;
+
+        for (i = 0; i < sizeof(a) - 1; i++)
+            *bufp++ = a[i];
+
+        for (p = funcName; *p; p++)
+            *bufp++ = *p;
+
+        for (i = 0; i < sizeof(b) - 1; i++)
+            *bufp++ = b[i];
+
+        *bufp++ = '\0';
+
+        OSFatal(buf);
+    }
+}
+
 void InitAcquireOS(void)
 {
-      //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     //! Lib handle functions
     //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     EXPORT_FUNC_WRITE(OSDynLoad_Acquire, (s32 (*)(const char*, unsigned *))OS_SPECIFICS->addr_OSDynLoad_Acquire);

--- a/os_functions.c
+++ b/os_functions.c
@@ -99,6 +99,8 @@ EXPORT_DECL(void *, MEMAllocFromExpHeapEx, s32 heap, u32 size, s32 align);
 EXPORT_DECL(s32 , MEMCreateExpHeapEx, void* address, u32 size, unsigned short flags);
 EXPORT_DECL(void *, MEMDestroyExpHeap, s32 heap);
 EXPORT_DECL(void, MEMFreeToExpHeap, s32 heap, void* ptr);
+EXPORT_DECL(void *, OSAllocFromSystem, int size, int alignment);
+EXPORT_DECL(void, OSFreeToSystem, void *addr);
 
 //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 //! MCP functions
@@ -268,6 +270,8 @@ void InitOSFunctionPointers(void)
     OS_FIND_EXPORT(coreinit_handle, MEMCreateExpHeapEx);
     OS_FIND_EXPORT(coreinit_handle, MEMDestroyExpHeap);
     OS_FIND_EXPORT(coreinit_handle, MEMFreeToExpHeap);
+    OS_FIND_EXPORT(coreinit_handle, OSAllocFromSystem);
+    OS_FIND_EXPORT(coreinit_handle, OSFreeToSystem);
 
     //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     //! Other function addresses

--- a/os_functions.h
+++ b/os_functions.h
@@ -140,6 +140,7 @@ extern void *(* MEMDestroyExpHeap)(s32 heap);
 extern void (* MEMFreeToExpHeap)(s32 heap, void* ptr);
 extern void* (* OSAllocFromSystem)(int size, int alignment);
 extern void (* OSFreeToSystem)(void *addr);
+extern int (* OSIsAddressValid)(void *ptr);
 
 //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 //! MCP functions

--- a/os_functions.h
+++ b/os_functions.h
@@ -138,6 +138,8 @@ extern void *(* MEMAllocFromExpHeapEx)(s32 heap, u32 size, s32 align);
 extern s32 (* MEMCreateExpHeapEx)(void* address, u32 size, unsigned short flags);
 extern void *(* MEMDestroyExpHeap)(s32 heap);
 extern void (* MEMFreeToExpHeap)(s32 heap, void* ptr);
+extern void* (* OSAllocFromSystem)(int size, int alignment);
+extern void (* OSFreeToSystem)(void *addr);
 
 //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 //! MCP functions

--- a/os_functions.h
+++ b/os_functions.h
@@ -49,25 +49,20 @@ extern "C" {
 
 #define EXPORT_FUNC_WRITE(func, val)    *(u32*)(((u32)&func) + 0) = (u32)val
 
-#define OS_FIND_EXPORT(handle, func)    funcPointer = 0;                                                                \
-                                        OSDynLoad_FindExport(handle, 0, # func, &funcPointer);                          \
-                                        if(!funcPointer)                                                                \
-                                            OSFatal("Function " # func " is NULL");                                     \
+#define OS_FIND_EXPORT(handle, func)    _os_find_export(handle, # func, &funcPointer);                                  \
                                         EXPORT_FUNC_WRITE(func, funcPointer);
 
 #define OS_FIND_EXPORT_EX(handle, func, func_p)                                                                         \
-                                        funcPointer = 0;                                                                \
-                                        OSDynLoad_FindExport(handle, 0, # func, &funcPointer);                          \
-                                        if(!funcPointer)                                                                \
-                                            OSFatal("Function " # func " is NULL");                                     \
+                                        _os_find_export(handle, # func, &funcPointer);                                  \
                                         EXPORT_FUNC_WRITE(func_p, funcPointer);
 
 #define OS_MUTEX_SIZE                   44
 
 /* Handle for coreinit */
 extern u32 coreinit_handle;
-void InitOSFunctionPointers(void);
-void InitAcquireOS(void);
+extern void _os_find_export(u32 handle, const char *funcName, void *funcPointer);
+extern void InitAcquireOS(void);
+extern void InitOSFunctionPointers(void);
 
 //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 //! Lib handle functions


### PR DESCRIPTION
Hi, this pull request adds three more memory functions from coreinit.rpl, and it tweaks .gitignore a little. But most importantly, I changed how OS_FIND_EXPORT works, and managed to shave quite a few kilobytes off this library!

Have fun reviewing :)