### PR TITLE
Add support for vpad gyro and angle

### DIFF
--- a/vpad_functions.h
+++ b/vpad_functions.h
@@ -75,6 +75,11 @@ typedef struct
 
 typedef struct
 {
+    f32 x,y,z;
+} Vec3D;
+
+typedef struct
+{
     u16 x, y;               /* Touch coordinates */
     u16 touched;            /* 1 = Touched, 0 = Not touched */
     u16 invalid;            /* 0 = All valid, 1 = X invalid, 2 = Y invalid, 3 = Both invalid? */
@@ -86,7 +91,10 @@ typedef struct
     u32 btns_d;                  /* Buttons that are pressed at that instant */
     u32 btns_r;                  /* Released buttons */
     Vec2D lstick, rstick;        /* Each contains 4-byte X and Y components */
-    char unknown1c[0x52 - 0x1c]; /* Contains accelerometer and gyroscope data somewhere */
+    char unknown1c[0x38 - 0x1c]; /* Contains accelerometer data somewhere */
+    Vec3D gyro;                  /* Gyro data */
+    Vec3D angle;                 /* Angle data */
+    char unknown50[0x52 - 0x50]; /* Two bytes of unknown data */
     VPADTPData tpdata;           /* Normal touchscreen data */
     VPADTPData tpdata1;          /* Modified touchscreen data 1 */
     VPADTPData tpdata2;          /* Modified touchscreen data 2 */


### PR DESCRIPTION
### Gyroscope
The following variables hold the current state of the GamePad's gyroscopes. 

Variable | Value
-------- | ------------------------------------------
gyro.x    | Rotation speed around X (horizontal) axis
gyro.y    | Rotation speed around Y (depth) axis
gyro.z    | Rotation speed around Z (vertical) axis

### Angle
The following variables hold the current angle of rotation of the GamePad. 

Variable | Value
-------- | ------------------------------------------
angle.x  | Rotation around X (horizontal) axis
angle.y  | Rotation around Y (depth) axis
angle.z  | Rotation around Z (vertical) axis

A change of 1.0 in these values represents a complete revolution around the specified axis. These variables do not appear to wrap around; multiple revolutions around the same axis will cause the value to continuously increase or decrease.

### Test
If you need to see those values in action, you can look at the Nintendo Wii U demonstration page at http://www.nintendo.com/wiiu/built-in-software/browser-specs/sample
Of course you need to open the link in the Wii U Internet Browser.

Here is an elf file to load in the Homebrew Launcher : [test.elf.gz](https://github.com/Maschell/dynamic_libs/files/963441/test.elf.gz)