### PR TITLE
Fix compiler warnings

### DIFF
--- a/fs_defs.h
+++ b/fs_defs.h
@@ -1,5 +1,5 @@
 #ifndef FS_DEFS_H
-#define	FS_DEFS_H
+#define FS_DEFS_H
 
 #include <gctypes.h>
 
@@ -57,5 +57,5 @@ typedef struct
 }
 #endif
 
-#endif	/* FS_DEFS_H */
+#endif  /* FS_DEFS_H */
 

--- a/os_functions.c
+++ b/os_functions.c
@@ -166,7 +166,7 @@ void _os_find_export(u32 handle, const char *funcName, void *funcPointer)
          */
         char buf[256], *bufp = buf;
         const char a[] = "Function ", b[] = " is NULL", *p;
-        int i;
+        unsigned int i;
 
         for (i = 0; i < sizeof(a) - 1; i++)
             *bufp++ = a[i];

--- a/syshid_functions.h
+++ b/syshid_functions.h
@@ -32,30 +32,30 @@ extern u32 syshid_handle;
 
 typedef struct
 {
-	u32 handle;
-	u32 physical_device_inst;
-	unsigned short vid;
-	unsigned short pid;
-	unsigned char interface_index;
-	unsigned char sub_class;
-	unsigned char protocol;
+    u32 handle;
+    u32 physical_device_inst;
+    unsigned short vid;
+    unsigned short pid;
+    unsigned char interface_index;
+    unsigned char sub_class;
+    unsigned char protocol;
 
-	unsigned short max_packet_size_rx;
-	unsigned short max_packet_size_tx;
+    unsigned short max_packet_size_rx;
+    unsigned short max_packet_size_tx;
 
 } HIDDevice;
 
 typedef struct _HIDClient HIDClient;
 
-#define HID_DEVICE_DETACH	0
-#define HID_DEVICE_ATTACH	1
+#define HID_DEVICE_DETACH   0
+#define HID_DEVICE_ATTACH   1
 
 typedef s32 (*HIDAttachCallback)(HIDClient *p_hc,HIDDevice *p_hd,u32 attach);
 
 struct _HIDClient
 {
-	HIDClient *next;
-	HIDAttachCallback attach_cb;
+    HIDClient *next;
+    HIDAttachCallback attach_cb;
 };
 
 typedef void (*HIDCallback)(u32 handle,s32 error,unsigned char *p_buffer,u32 bytes_transferred,void *p_user);

--- a/vpad_functions.h
+++ b/vpad_functions.h
@@ -99,9 +99,9 @@ typedef struct
     VPADTPData tpdata1;          /* Modified touchscreen data 1 */
     VPADTPData tpdata2;          /* Modified touchscreen data 2 */
     char unknown6a[0xa0 - 0x6a];
-    uint8_t volume;
-    uint8_t battery;             /* 0 to 6 */
-    uint8_t unk_volume;          /* One less than volume */
+    u8 volume;
+    u8 battery;                  /* 0 to 6 */
+    u8 unk_volume;               /* One less than volume */
     char unknowna4[0xac - 0xa4];
 } VPADData;
 


### PR DESCRIPTION
These are the two warnings that I have fixed in _os_functions.c_:
```
/src/dynamic_libs/os_functions.c: In function '_os_find_export':
/src/dynamic_libs/os_functions.c:171:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         for (i = 0; i < sizeof(a) - 1; i++)
                       ^
/src/dynamic_libs/os_functions.c:177:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         for (i = 0; i < sizeof(b) - 1; i++)
                       ^
```

I have also change tab to spaces in two files (_fs_defs.h_ & _syshid_functions.h_) and use **u8** instead of **uint8_t** in the **VPADData** struct (_vpad_functions.h_).