### PR TITLE
Add OSScreenPutPixelEx function

### DIFF
--- a/fs_functions.c
+++ b/fs_functions.c
@@ -31,7 +31,7 @@ EXPORT_DECL(s32, FSDelClient, void *pClient);
 EXPORT_DECL(void, FSInitCmdBlock, void *pCmd);
 EXPORT_DECL(s32, FSGetMountSource, void *pClient, void *pCmd, s32 type, void *source, s32 errHandling);
 
-EXPORT_DECL(s32, FSMount, void *pClient, void *pCmd, void *source, char *target, uint32_t bytes, s32 errHandling);
+EXPORT_DECL(s32, FSMount, void *pClient, void *pCmd, void *source, char *target, u32 bytes, s32 errHandling);
 EXPORT_DECL(s32, FSUnmount, void *pClient, void *pCmd, const char *target, s32 errHandling);
 
 EXPORT_DECL(s32, FSGetStat, void *pClient, void *pCmd, const char *path, FSStat *stats, s32 errHandling);

--- a/fs_functions.h
+++ b/fs_functions.h
@@ -40,7 +40,7 @@ extern s32 (* FSDelClient)(void *pClient);
 extern void (* FSInitCmdBlock)(void *pCmd);
 extern s32 (* FSGetMountSource)(void *pClient, void *pCmd, s32 type, void *source, s32 errHandling);
 
-extern s32 (* FSMount)(void *pClient, void *pCmd, void *source, char *target, uint32_t bytes, s32 errHandling);
+extern s32 (* FSMount)(void *pClient, void *pCmd, void *source, char *target, u32 bytes, s32 errHandling);
 extern s32 (* FSUnmount)(void *pClient, void *pCmd, const char *target, s32 errHandling);
 extern s32 (* FSRename)(void *pClient, void *pCmd, const char *oldPath, const char *newPath, s32 error);
 extern s32 (* FSRenameAsync)(void *pClient, void *pCmd, const char *oldPath, const char *newPath, s32 error, void *asyncParams);

--- a/os_functions.c
+++ b/os_functions.c
@@ -83,6 +83,7 @@ EXPORT_DECL(s32, OSScreenClearBufferEx, u32 bufferNum, u32 temp);
 EXPORT_DECL(s32, OSScreenFlipBuffersEx, u32 bufferNum);
 EXPORT_DECL(s32, OSScreenPutFontEx, u32 bufferNum, u32 posX, u32 posY, const char * buffer);
 EXPORT_DECL(s32, OSScreenEnableEx, u32 bufferNum, s32 enable);
+EXPORT_DECL(u32, OSScreenPutPixelEx, u32 bufferNum, u32 posX, u32 posY, u32 color);
 
 //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 //! Memory functions
@@ -127,7 +128,7 @@ EXPORT_DECL(void, addr_PrepareTitle_hook, void);
 //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 //! Other function addresses
 //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-EXPORT_DECL(void, DCInvalidateRange, void *buffer, uint32_t length);
+EXPORT_DECL(void, DCInvalidateRange, void *buffer, u32 length);
 
 //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 //! Energy Saver functions
@@ -226,6 +227,7 @@ void InitOSFunctionPointers(void)
     OS_FIND_EXPORT(coreinit_handle, OSScreenFlipBuffersEx);
     OS_FIND_EXPORT(coreinit_handle, OSScreenPutFontEx);
     OS_FIND_EXPORT(coreinit_handle, OSScreenEnableEx);
+    OS_FIND_EXPORT(coreinit_handle, OSScreenPutPixelEx);
     //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     //! Thread functions
     //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/os_functions.h
+++ b/os_functions.h
@@ -119,6 +119,7 @@ extern s32 (*OSScreenClearBufferEx)(u32 bufferNum, u32 temp);
 extern s32 (*OSScreenFlipBuffersEx)(u32 bufferNum);
 extern s32 (*OSScreenPutFontEx)(u32 bufferNum, u32 posX, u32 posY, const char * buffer);
 extern s32 (*OSScreenEnableEx)(u32 bufferNum, s32 enable);
+extern u32 (*OSScreenPutPixelEx)(u32 bufferNum, u32 posX, u32 posY, u32 color);
 
 typedef unsigned char (*exception_callback)(void * interruptedContext);
 extern void (* OSSetExceptionCallback)(u8 exceptionType, exception_callback newCallback);
@@ -166,7 +167,7 @@ extern void (* addr_PrepareTitle_hook)(void);
 //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 //! Other function addresses
 //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-extern void (*DCInvalidateRange)(void *buffer, uint32_t length);
+extern void (*DCInvalidateRange)(void *buffer, u32 length);
 
 //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 //! Energy Saver functions


### PR DESCRIPTION
**OSScreenPutPixelEx** will draw a pixel of a certain color to the specified coordinates. This just writes the input u32 to the target location in the framebuffer, nothing is done with the data already stored in the framebuffer.

Usage (draw a line):
```cpp
for(int x = 50; x < 600; ++x)
{
    OSScreenPutPixelEx(1, x, 20, 0xFF8000FF);
}
```