### PR TITLE
Fix linking problem with KPADReadEx

### DIFF
--- a/padscore_functions.c
+++ b/padscore_functions.c
@@ -32,7 +32,8 @@ EXPORT_DECL(s32, WPADProbe, s32 chan, u32 * pad_type);
 EXPORT_DECL(s32, WPADSetDataFormat, s32 chan, s32 format);
 EXPORT_DECL(void, WPADEnableURCC, s32 enable);
 EXPORT_DECL(void, WPADRead, s32 chan, void * data);
-EXPORT_DECL(s32, KPADRead, s32 chan, void * data, u32 size);
+EXPORT_DECL(s32, KPADRead, s32 chan, KPADData * data, u32 size);
+EXPORT_DECL(s32, KPADReadEx, s32 chan, KPADData * data, u32 size, s32 *error);
 EXPORT_DECL(void,WPADSetAutoSleepTime,u8 minute);
 EXPORT_DECL(void,WPADDisconnect,s32 chan);
 
@@ -53,6 +54,7 @@ void InitPadScoreFunctionPointers(void)
     OS_FIND_EXPORT(padscore_handle, WPADEnableURCC);
     OS_FIND_EXPORT(padscore_handle, WPADRead);
     OS_FIND_EXPORT(padscore_handle, KPADRead);
+    OS_FIND_EXPORT(padscore_handle, KPADReadEx);
     OS_FIND_EXPORT(padscore_handle, WPADSetAutoSleepTime);
     OS_FIND_EXPORT(padscore_handle, WPADDisconnect);
 

--- a/padscore_functions.h
+++ b/padscore_functions.h
@@ -188,7 +188,7 @@ extern s32 (* WPADProbe)(s32 chan, u32 * pad_type);
 extern s32 (* WPADSetDataFormat)(s32 chan, s32 format);
 extern void (* WPADEnableURCC)(s32 enable);
 extern void (* WPADRead)(s32 chan, void * data);
-extern s32 (* KPADRead)(s32 chan, void * data, u32 size);
+extern s32 (* KPADRead)(s32 chan, KPADData * data, u32 size);
 extern s32 (* KPADReadEx)(s32 chan, KPADData * data, u32 size, s32 *error);
 extern void (*WPADSetAutoSleepTime)(u8 time);
 extern void (*WPADDisconnect)( s32 chan );


### PR DESCRIPTION
Fix linking problem with the `KPADReadEx` function.

The `void*` parameter from `KPADRead` was also changed to `KPADData`.