### PR TITLE
Replace BOOL by s32

### DIFF
--- a/os_functions.c
+++ b/os_functions.c
@@ -273,18 +273,18 @@ void InitOSFunctionPointers(void)
     OS_FIND_EXPORT(coreinit_handle, OSScreenPutPixelEx);
 
     OS_FIND_EXPORT(coreinit_handle, DisassemblePPCRange);
-	OS_FIND_EXPORT(coreinit_handle, DisassemblePPCOpcode);
-	OS_FIND_EXPORT(coreinit_handle, OSGetSymbolName);
+    OS_FIND_EXPORT(coreinit_handle, DisassemblePPCOpcode);
+    OS_FIND_EXPORT(coreinit_handle, OSGetSymbolName);
     OS_FIND_EXPORT(coreinit_handle, OSIsDebuggerInitialized);
     //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     //! Thread functions
     //!----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     OS_FIND_EXPORT(coreinit_handle, OSEnableInterrupts);
-	OS_FIND_EXPORT(coreinit_handle, __OSClearAndEnableInterrupt);
-	OS_FIND_EXPORT(coreinit_handle, OSIsInterruptEnabled);
-	OS_FIND_EXPORT(coreinit_handle, OSIsDebuggerPresent);
-	OS_FIND_EXPORT(coreinit_handle, OSRestoreInterrupts);
-	OS_FIND_EXPORT(coreinit_handle, OSSetDABR);
+    OS_FIND_EXPORT(coreinit_handle, __OSClearAndEnableInterrupt);
+    OS_FIND_EXPORT(coreinit_handle, OSIsInterruptEnabled);
+    OS_FIND_EXPORT(coreinit_handle, OSIsDebuggerPresent);
+    OS_FIND_EXPORT(coreinit_handle, OSRestoreInterrupts);
+    OS_FIND_EXPORT(coreinit_handle, OSSetDABR);
     OS_FIND_EXPORT(coreinit_handle, OSSetIABR);
 
     OS_FIND_EXPORT(coreinit_handle, OSCreateThread);

--- a/os_types.h
+++ b/os_types.h
@@ -35,10 +35,10 @@ typedef struct OSThreadLink_ {
 }  OSThreadLink;
 
 typedef struct OSThreadQueue_ {
-	OSThread *head;
-	OSThread *tail;
-	void *parentStruct;
-	u32 reserved;
+    OSThread *head;
+    OSThread *tail;
+    void *parentStruct;
+    u32 reserved;
 } OSThreadQueue;
 
 typedef struct OSMessage_ {
@@ -62,46 +62,46 @@ typedef struct OSMessageQueue_ {
 } OSMessageQueue;
 
 typedef struct OSContext_ {
-	char tag[8];
+    char tag[8];
 
-	u32 gpr[32];
+    u32 gpr[32];
 
-	u32 cr;
-	u32 lr;
-	u32 ctr;
-	u32 xer;
+    u32 cr;
+    u32 lr;
+    u32 ctr;
+    u32 xer;
 
-	u32 srr0;
-	u32 srr1;
+    u32 srr0;
+    u32 srr1;
 
-	u32 ex0;
-	u32 ex1;
+    u32 ex0;
+    u32 ex1;
 
-	u32 exception_type;
-	u32 reserved;
+    u32 exception_type;
+    u32 reserved;
 
-	double fpscr;
-	double fpr[32];
+    double fpscr;
+    double fpr[32];
 
-	u16 spinLockCount;
-	u16 state;
+    u16 spinLockCount;
+    u16 state;
 
-	u32 gqr[8];
-	u32 pir;
-	double psf[32];
+    u32 gqr[8];
+    u32 pir;
+    double psf[32];
 
-	u64 coretime[3];
-	u64 starttime;
+    u64 coretime[3];
+    u64 starttime;
 
-	u32 error;
-	u32 attributes;
+    u32 error;
+    u32 attributes;
 
-	u32 pmc1;
-	u32 pmc2;
-	u32 pmc3;
-	u32 pmc4;
-	u32 mmcr0;
-	u32 mmcr1;
+    u32 pmc1;
+    u32 pmc2;
+    u32 pmc3;
+    u32 pmc4;
+    u32 mmcr0;
+    u32 mmcr1;
 } OSContext;
 
 typedef enum OSExceptionType
@@ -137,7 +137,7 @@ struct OSThread_ {
     int priority;
 
     char _[0x394 - 0x330 - sizeof(OSThreadLink)];
-	OSThreadLink linkActive;
+    OSThreadLink linkActive;
 
     void *stackBase;
     void *stackEnd;

--- a/socket_functions.h
+++ b/socket_functions.h
@@ -53,7 +53,7 @@ extern u32 hostIpAddress;
 #define SO_BROADCAST    0x0020      // broadcast
 #define SO_NONBLOCK     0x1016
 #define SO_MYADDR       0x1013
-#define SO_RCVTIMEO	0x1006
+#define SO_RCVTIMEO     0x1006
 
 #define SOL_SOCKET      -1
 #define MSG_DONTWAIT    32

--- a/vpad_functions.h
+++ b/vpad_functions.h
@@ -129,7 +129,7 @@ typedef struct
     VPADTPData tpdata1;          /* Modified touchscreen data 1 */
     VPADTPData tpdata2;          /* Modified touchscreen data 2 */
     VPADDir dir;                 /* Orientation in three-dimensional space */
-    BOOL headphone;              /* Set to TRUE if headphones are plugged in, FALSE otherwise */
+    s32 headphone;               /* Set to TRUE if headphones are plugged in, FALSE otherwise */
     Vec3D mag;                   /* Magnetometer data */
     u8 volume;                   /* 0 to 255 */
     u8 battery;                  /* 0 to 6 */


### PR DESCRIPTION
This is to fix issue #18.

Here is a small [test](https://github.com/Maschell/dynamic_libs/files/1351002/test.zip) for the VPADData structure. It will show these values:
```
    Vec2D lstick, rstick;        /* Each contains 4-byte X and Y components */
    s8 error;                    /* Error */
    VPADTPData tpdata;           /* Normal touchscreen data */
    s32 headphone;               /* Set to TRUE if headphones are plugged in, FALSE otherwise */
    u8 volume;                   /* 0 to 255 */
    u8 battery;                  /* 0 to 6 */
    u8 mic;                      /* Microphone status */
    u8 unk_volume;               /* One less than volume */
```

I have also converted some tabs to spaces.