### PR TITLE
Add Travis CI file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: c
+sudo: false
+
+os:
+  - linux
+
+env:
+  global:
+    - DEVKITPRO=$HOME/devkitPro
+    - DEVKITPPC=${DEVKITPRO}/devkitPPC
+
+cache:
+  directories:
+    - ${DEVKITPRO}
+
+addons:
+  apt:
+    packages:
+    - p7zip-full
+
+before_install:
+  - wget https://raw.githubusercontent.com/devkitPro/installer/master/perl/devkitPPCupdate.pl
+
+install:
+  - perl devkitPPCupdate.pl
+  - 7z x -y ./libs/portlibs.zip -o${DEVKITPRO}
+
+script:
+  - make


### PR DESCRIPTION
Added a _.travis.yml_ file to allow Travis CI to compile the lib each time a commit is done. This will also help validate pull requests.

It is configured to always take the latest DevkitPro release.

@Maschell you will need to add the repository to [Travis CI](https://travis-ci.org/Maschell/dynamic_libs) to make it work.

You may also add this badge to the readme file:
`[![Build Status](https://travis-ci.org/Maschell/dynamic_libs.svg?branch=master)](https://travis-ci.org/Maschell/dynamic_libs)`
The result:
[![Build Status](https://travis-ci.org/Maschell/dynamic_libs.svg?branch=master)](https://travis-ci.org/Maschell/dynamic_libs)

If you need help, let me know :)