### PR TITLE
Add more socket functions

### DIFF
--- a/source/gx2_functions.c
+++ b/source/gx2_functions.c
@@ -97,7 +97,7 @@ EXPORT_DECL(s32, GX2GetLastFrame, s32 target, GX2Texture * texture);
 EXPORT_DECL(void, GX2BeginDisplayListEx,void * displayList,u32 size,s32 unkwn);
 EXPORT_DECL(u32, GX2EndDisplayList, void * list);
 EXPORT_DECL(void, GX2CallDisplayList, void * list, u32 size);
-EXPORT_DECL(void, GX2ExpandAAColorBuffer,GX2ColorBuffer * buffer); 	
+EXPORT_DECL(void, GX2ExpandAAColorBuffer,GX2ColorBuffer * buffer);
 EXPORT_DECL(void, GX2ResolveAAColorBuffer, const GX2ColorBuffer * srcBuffer, GX2Surface * dstSurface,u32 dstMip,u32 dstSlice);
 
 EXPORT_DECL(void, GX2ClearBuffersEx, GX2ColorBuffer * colorBuffer,GX2DepthBuffer * depthBuffer,f32 r, f32 g, f32 b, f32 a,f32 depthValue,u8 stencilValue,s32 clearFlags);
@@ -179,7 +179,7 @@ void InitGX2FunctionPointers(void){
     OS_FIND_EXPORT(gx2_handle, GX2BeginDisplayListEx);
     OS_FIND_EXPORT(gx2_handle, GX2EndDisplayList);
     OS_FIND_EXPORT(gx2_handle, GX2CallDisplayList);
-    OS_FIND_EXPORT(gx2_handle, GX2ExpandAAColorBuffer);    
-    OS_FIND_EXPORT(gx2_handle, GX2ResolveAAColorBuffer);    
+    OS_FIND_EXPORT(gx2_handle, GX2ExpandAAColorBuffer);
+    OS_FIND_EXPORT(gx2_handle, GX2ResolveAAColorBuffer);
     OS_FIND_EXPORT(gx2_handle, GX2SetClearDepthStencil);
 }

--- a/source/gx2_functions.h
+++ b/source/gx2_functions.h
@@ -107,9 +107,9 @@ extern s32 (* GX2GetLastFrame)(s32 target, GX2Texture * texture);
 extern void (* GX2BeginDisplayListEx)(void * displayList,u32 size,s32 unkwn);
 extern u32 (*GX2EndDisplayList)(void * list);
 extern void (*GX2CallDisplayList)(void * list, u32 size);
-extern void (*GX2ExpandAAColorBuffer)(GX2ColorBuffer * buffer); 
+extern void (*GX2ExpandAAColorBuffer)(GX2ColorBuffer * buffer);
 extern void (*GX2ResolveAAColorBuffer)(const GX2ColorBuffer * srcBuffer, GX2Surface * dstSurface,u32 dstMip,u32 dstSlice);
-    
+
 static inline void GX2InitDepthBuffer(GX2DepthBuffer *depthBuffer, s32 dimension, u32 width, u32 height, u32 depth, s32 format, s32 aa)
 {
     depthBuffer->surface.dimension = dimension;

--- a/source/os_functions.c
+++ b/source/os_functions.c
@@ -127,7 +127,7 @@ EXPORT_VAR(u32 *, pMEMFreeToDefaultHeap);
 
 EXPORT_DECL(void *, MEMAllocFromAllocator, void * allocator, u32 size);
 EXPORT_DECL(void, MEMFreeToAllocator, void * allocator, void* address);
-EXPORT_DECL(s32, MEMGetBaseHeapHandle, s32 mem_arena);                                 
+EXPORT_DECL(s32, MEMGetBaseHeapHandle, s32 mem_arena);
 EXPORT_DECL(u32, MEMGetAllocatableSizeForExpHeapEx, s32 heap, s32 align);
 EXPORT_DECL(u32, MEMGetAllocatableSizeForFrmHeapEx, s32 heap, s32 align);
 EXPORT_DECL(void *, MEMAllocFromFrmHeapEx, s32 heap, u32 size, s32 align);

--- a/source/socket_functions.c
+++ b/source/socket_functions.c
@@ -44,6 +44,8 @@ EXPORT_DECL(s32, sendto, s32 s, const void *buffer, s32 size, s32 flags, const s
 EXPORT_DECL(s32, setsockopt, s32 s, s32 level, s32 optname, void *optval, s32 optlen);
 EXPORT_DECL(char *, inet_ntoa, struct in_addr in);
 EXPORT_DECL(s32, inet_aton, const char *cp, struct in_addr *inp);
+EXPORT_DECL(const char *, inet_ntop, s32 af, const void *src, char *dst, s32 size);
+EXPORT_DECL(s32, inet_pton, s32 af, const char *src, void *dst);
 EXPORT_DECL(s32, socketlasterr, void);
 
 EXPORT_DECL(s32, NSSLWrite, s32 connection, const void* buf, s32 len,s32 * written);
@@ -88,6 +90,8 @@ void InitSocketFunctionPointers(void){
     OS_FIND_EXPORT(nsysnet_handle, setsockopt);
     OS_FIND_EXPORT(nsysnet_handle, inet_ntoa);
     OS_FIND_EXPORT(nsysnet_handle, inet_aton);
+    OS_FIND_EXPORT(nsysnet_handle, inet_ntop);
+    OS_FIND_EXPORT(nsysnet_handle, inet_pton);
 
     OS_FIND_EXPORT(nsysnet_handle, NSSLWrite);
     OS_FIND_EXPORT(nsysnet_handle, NSSLRead);

--- a/source/socket_functions.h
+++ b/source/socket_functions.h
@@ -110,6 +110,8 @@ extern s32 (* NSSLCreateConnection)(s32 context, const char* host, s32 hotlen,s3
 
 extern char * (*inet_ntoa)(struct in_addr in);
 extern s32 (*inet_aton)(const char *cp, struct in_addr *inp);
+extern const char * (*inet_ntop)(s32 af, const void *src, char *dst, s32 size);
+extern s32 (*inet_pton)(s32 af, const char *src, void *dst);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The _inet_ntop_ and _inet_pton_ functions were added.

Usage example:
```cpp
u8 IP[4] = {0, 0, 0, 0};
inet_pton(AF_INET, "5.6.7.254", &IP);

char * IP_str = (char*)malloc(32);
inet_ntop(AF_INET, &IP, IP_str, 32);
```