### PR TITLE
Add pkg-config support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,13 @@
 .SUFFIXES:
 #---------------------------------------------------------------------------------
 ifeq ($(strip $(DEVKITPPC)),)
-$(error "Please set DEVKITPPC in your environment. export DEVKITPPC=<path to>devkitPPC)
+$(error "Please set DEVKITPPC in your environment. export DEVKITPPC=<path to>devkitPPC")
 endif
 ifeq ($(strip $(DEVKITPRO)),)
 $(error "Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>devkitPRO")
 endif
+
+GITTAG ?= $(shell git describe --tags)
 
 export PATH			:=	$(DEVKITPPC)/bin:$(PORTLIBS)/bin:$(PATH)
 export PORTLIBS		:=	$(DEVKITPRO)/portlibs/ppc
@@ -32,6 +34,7 @@ include $(DEVKITPPC)/base_rules
 BUILD		?=	release
 SOURCES		:=	source
 INCLUDES	:=	include
+PKGCONFS	:=	pkgconf
 DATA		:=
 LIB		:=	lib
 
@@ -44,11 +47,12 @@ CXXFLAGS	=	$(CFLAGS)
 ASFLAGS	:=	-g
 
 export WIIUBIN	:=	$(LIB)/libdynamiclibs.a
+export PKGCONF	:=	dynamic_libs.pc
 
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project
 #---------------------------------------------------------------------------------
-LIBS	:= 
+LIBS	:=
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
@@ -69,7 +73,8 @@ export TOPDIR ?= $(CURDIR)/..
 export DEPSDIR := $(CURDIR)/$(BUILD)
 
 export VPATH	:=	$(foreach dir,$(SOURCES),$(CURDIR)/$(dir)) \
-			$(foreach dir,$(DATA),$(CURDIR)/$(dir))
+			$(foreach dir,$(DATA),$(CURDIR)/$(dir)) \
+			$(foreach dir,$(PKGCONFS),$(CURDIR)/$(dir))
 
 CFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.c)))
 CPPFILES	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.cpp)))
@@ -84,12 +89,12 @@ export INCLUDE	:=	$(foreach dir,$(INCLUDES),-I$(CURDIR)/$(dir)) \
 			$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
 			$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
 			-I$(CURDIR)/$(BUILD) -I$(PORTLIBS)/include -I$(PORTLIBS)/include
-			
-			
+
+
 
 export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib) $(PORTLIBS)/lib
 
-.PHONY: $(BUILD) clean
+.PHONY: $(BUILD) clean all install
 
 #---------------------------------------------------------------------------------
 $(BUILD):
@@ -99,14 +104,18 @@ $(BUILD):
 #---------------------------------------------------------------------------------
 clean:
 	@echo clean ...
-	@rm -fr debug release $(LIB) include
+	@rm -fr debug release $(LIB) include $(PKGCONF)
 
-all: $(WIIUBIN)
+all: $(BUILD)
 
-install:
+install: $(BUILD)
+	@mkdir -p $(PORTLIBS)/lib
 	@cp $(BUILD)/lib/libdynamiclibs.a $(PORTLIBS)/lib
 	@mkdir -p $(PORTLIBS)/include/dynamic_libs
 	@cp source/*.h $(PORTLIBS)/include/dynamic_libs
+	@mkdir -p $(PORTLIBS)/lib/pkgconfig
+	@cp $(BUILD)/$(PKGCONF) $(PORTLIBS)/lib/pkgconfig
+	@echo Installed!
 
 #---------------------------------------------------------------------------------
 else
@@ -116,7 +125,13 @@ DEPENDS	:=	$(OFILES:.o=.d)
 #---------------------------------------------------------------------------------
 # main targets
 #---------------------------------------------------------------------------------
-$(WIIUBIN)	:	$(OFILES) $(LIB)
+all: $(WIIUBIN) $(PKGCONF)
+
+%.pc: %.pc.in
+	@sed "s;@PREFIX@;$(PORTLIBS);g" $< > $@
+	@sed "s;@VERSION@;$(GITTAG);g" $< > $@
+
+$(WIIUBIN):	$(OFILES) $(LIB)
 	@rm -f "$(WIIUBIN)"
 	@$(AR) rcs "$(WIIUBIN)" $(OFILES)
 	@echo built ... $(notdir $@)
@@ -129,4 +144,3 @@ $(LIB):
 #---------------------------------------------------------------------------------------
 endif
 #---------------------------------------------------------------------------------------
-

--- a/pkgconf/dynamic_libs.pc.in
+++ b/pkgconf/dynamic_libs.pc.in
@@ -1,0 +1,11 @@
+dynamic_libs.pc:
+prefix=@PREFIX@
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: dynamic_libs
+Description: Dynamic libs for WiiU homebrew
+Version: @VERSION@
+
+Cflags: -I${includedir}/dynamic_libs
+Libs: -L${libdir} -ldynamiclibs


### PR DESCRIPTION
Heyo!
Just a few Makefile tweaks to generate a pkg-config file to go with libdynamiclibs.a. pkg-config can make building things a lot simpler - instead of hardcoding paths to portlibs or devkitpro, you can run a command to generate the needed cflags and ldflags for you. For example, here's what my system now does (using devkitpro's pkg-config)
```
[ash@ash-pizza $] powerpc-eabi-pkg-config dynamic_libs --libs --static
-L/opt/devkitpro/portlibs/ppc/lib -ldynamiclibs
[ash@ash-pizza $] powerpc-eabi-pkg-config dynamic_libs --cflags --static
-I/opt/devkitpro/portlibs/ppc/include/dynamic_libs
```
You can see how this could be integrated into a Makefile to simplify things quite a bit. pkg-config also handles dependencies, so libraries that need dynamic_libs (like libutils) can pull it in without the user having to explicitly link it.

Thanks again!
Ash